### PR TITLE
Fix and add specific testing around Read and AsyncRead impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ utf-8 = "0.7"
 
 [dev-dependencies]
 tokio-test = "0.4"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros", "io-util"] }
+tokio-util = { version = "0.6", features = ["compat"] }
 proptest = "0.10"
 flate2 = "1.0"
 serial_test = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logdna-client"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["engineering@logdna.com"]
 edition = "2018"
 license = "MIT"

--- a/src/body.rs
+++ b/src/body.rs
@@ -31,7 +31,7 @@ impl core::fmt::Debug for IngestBodyBuffer {
         let buf = self
             .buf
             .buf
-            .reader()
+            .bytes_reader()
             .bytes()
             .collect::<Result<Vec<u8>, _>>()
             .unwrap();
@@ -65,7 +65,7 @@ impl IngestBodyBuffer {
     }
 
     pub fn reader(&self) -> impl std::io::Read + futures::AsyncBufRead + '_ {
-        self.buf.buf.reader()
+        self.buf.buf.bytes_reader()
     }
 }
 

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -227,6 +227,7 @@ impl Buf for SegmentedBuf<Reusable<Buffer>> {
         loop {
             let avail = self.bufs[self.read_pos].len() - self.read_offset;
 
+            debug_assert!(avail != 0);
             if avail > rem {
                 self.read_offset += rem;
                 break;
@@ -620,6 +621,7 @@ impl Buf for SegmentedBufBytesReader<'_> {
         loop {
             let avail = self.buf[self.read_pos].len() - self.read_offset;
 
+            debug_assert!(avail != 0);
             if avail > rem {
                 self.read_offset += rem;
                 break;

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -818,13 +818,17 @@ mod test {
             let mut reader = buf.buf.bytes_reader();
             // walk across reader efficiently
 
+            let mut output = vec![];
             let mut count = 0;
             while reader.remaining() > 0 {
+                output.extend_from_slice(&reader.chunk()[..]);
                 let item_len = reader.chunk().len();
                 assert!(item_len > 0);
                 reader.advance(item_len);
                 count += item_len;
             }
+            // Check the values were copied correctly
+            assert_eq!(output, values);
             // Check that it was all read
             assert_eq!(count, size);
             // Check that there's nothing left
@@ -840,6 +844,7 @@ mod test {
             while count < size {
                 let step = std::cmp::min(max_step, buf.remaining());
                 assert!(!buf.chunk().is_empty());
+
                 buf.advance(step);
                 count += step;
             }
@@ -853,13 +858,17 @@ mod test {
             buf.reset_read();
             assert_eq!(buf.remaining(), size);
 
+            let mut output = vec![];
             let mut count = 0;
             while buf.remaining() > 0 {
+                output.extend_from_slice(&buf.chunk()[..]);
                 let item_len = buf.chunk().len();
                 assert!(item_len > 0);
                 buf.advance(item_len);
                 count += item_len;
             }
+            // Check the values were copied correctly
+            assert_eq!(output, values);
             // Check that it was all read
             assert_eq!(count, size);
             // Check that there's nothing left

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -813,6 +813,23 @@ mod test {
             assert_eq!(reader.chunk().len(),  0);
             assert_eq!(reader.remaining(), 0);
 
+            let mut reader = buf.buf.bytes_reader();
+            // walk across reader efficiently
+
+            let mut count = 0;
+            while reader.remaining() > 0 {
+                let item_len = reader.chunk().len();
+                assert!(item_len > 0);
+                reader.advance(item_len);
+                count += item_len;
+            }
+            // Check that it was all read
+            assert_eq!(count, size);
+            // Check that there's nothing left
+            assert_eq!(reader.chunk().len(),  0);
+            assert_eq!(reader.remaining(), 0);
+
+
             // Check advancing the reader didn't effect the main buffer Buf impl
             assert_eq!(buf_remaining, buf.remaining());
 
@@ -831,7 +848,21 @@ mod test {
             assert_eq!(buf.chunk().len(),  0);
             assert_eq!(buf.remaining(), 0);
 
+            buf.reset_read();
+            assert_eq!(buf.remaining(), size);
 
+            let mut count = 0;
+            while buf.remaining() > 0 {
+                let item_len = buf.chunk().len();
+                assert!(item_len > 0);
+                buf.advance(item_len);
+                count += item_len;
+            }
+            // Check that it was all read
+            assert_eq!(count, size);
+            // Check that there's nothing left
+            assert_eq!(buf.chunk().len(),  0);
+            assert_eq!(buf.remaining(), 0);
         }
     }
 

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -797,13 +797,13 @@ mod test {
             let mut writer: Vec<u8> = Vec::with_capacity(inp.0);
             let mut reader = buf.buf.bytes_reader();
             std::io::copy(&mut reader, &mut writer).unwrap();
-            assert_eq!(inp.0, writer.len());
+            assert_eq!(inp.1, writer);
 
             // Test Buf impl (via it's reader adapter)
             let mut writer: Vec<u8> = vec![0; inp.0];
             let mut reader = buf.reader();
             std::io::Read::read(&mut reader, &mut writer[0..inp.0]).unwrap();
-            assert_eq!(inp.0, writer.len());
+            assert_eq!(inp.1, writer);
         }
 
     }
@@ -825,7 +825,7 @@ mod test {
                 let mut writer = vec![].compat_write();
                 let reader = buf.buf.bytes_reader();
                 tokio::io::copy(&mut reader.compat(), &mut writer).await.unwrap();
-                assert_eq!(inp.0, writer.get_ref().len());
+                assert_eq!(&inp.1, writer.get_ref());
                 buf
             });
 

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -802,7 +802,7 @@ mod test {
             let mut count = 0;
             while count < size {
                 let step = std::cmp::min(max_step, reader.remaining());
-                assert!(reader.chunk().len() > 0);
+                assert!(!reader.chunk().is_empty());
                 reader.advance(step);
                 count += step;
             }
@@ -820,7 +820,7 @@ mod test {
             let mut count = 0;
             while count < size {
                 let step = std::cmp::min(max_step, buf.remaining());
-                assert!(buf.chunk().len() > 0);
+                assert!(!buf.chunk().is_empty());
                 buf.advance(step);
                 count += step;
             }

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -783,13 +783,12 @@ mod test {
             buf.write_all(&inp.1).unwrap();
 
             assert_eq!(buf.len(), inp.0);
-            assert_eq!(buf.iter()
+            assert!(buf.iter()
                        .zip(inp.1.iter())
                        .fold(true,
                              |acc, (a, b)|{
                                  acc && (a == *b)
-                             }),
-                       true);
+                             }));
 
             assert_eq!(inp.0, buf.iter().count());
 
@@ -830,13 +829,13 @@ mod test {
             });
 
             assert_eq!(buf.len(), inp.0);
-            assert_eq!(buf.iter()
+            assert!(buf.iter()
                        .zip(inp.1.iter())
                        .fold(true,
                              |acc, (a, b)|{
                                  acc && (a == *b)
-                             }),
-                       true);
+                             })
+                       );
             assert_eq!(inp.0, buf.iter().count());
 
         }
@@ -859,13 +858,13 @@ mod test {
                 assert!(res.is_err());
             } else {{
                 res.unwrap();
-                assert_eq!(buf.iter()
+                assert!(buf.iter()
                            .zip(inp.1.iter())
                            .fold(true,
                                  |acc, (a, b)|{
                                      acc && (a == *b)
-                                 }),
-                           true);
+                                 })
+                           );
                 assert_eq!(inp.0, buf.iter().count());
             }}
 
@@ -911,12 +910,10 @@ mod test {
         use std::io::Write;
         buf.write_all(&inp).unwrap();
 
-        assert_eq!(
-            buf.iter()
-                .zip(inp.iter())
-                .fold(true, |acc, (a, b)| { acc && (a == *b) }),
-            true
-        );
+        assert!(buf
+            .iter()
+            .zip(inp.iter())
+            .fold(true, |acc, (a, b)| { acc && (a == *b) }));
 
         // Ensure we never allocated more buffers than were needed to hold the total elements
         fence(Ordering::SeqCst);


### PR DESCRIPTION
The previous implementation of Read and AsyncRead was only processing the first segment of the buffers.