### PR TITLE
Send errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ where
     Utf8(std::str::Utf8Error),
     FromUtf8(std::string::FromUtf8Error),
     Serialization(serde_json::Error),
-    Other(Box<dyn std::error::Error>),
+    Other(Box<dyn std::error::Error + Send + 'static>),
 }
 
 impl<T> From<RequestError> for HttpError<T>


### PR DESCRIPTION
This makes the client's Error types Send and 'static (they already were, this just adds the bounds). This allows the client to be used in parallel