### PR TITLE
fix: ParamsBuilder.ip was setting the wrong field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logdna-client"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["engineering@logdna.com"]
 edition = "2018"
 license = "MIT"

--- a/src/params.rs
+++ b/src/params.rs
@@ -70,7 +70,7 @@ impl ParamsBuilder {
     }
     /// Sets the ip field, optional
     pub fn ip<T: Into<String>>(&mut self, ip: T) -> &mut Self {
-        self.hostname = Some(ip.into());
+        self.ip = Some(ip.into());
         self
     }
     /// Sets the tags field, optional


### PR DESCRIPTION
The paramsbuilder ip setter was setting the hostname field