### PR TITLE
Add dns backoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,21 @@ async-trait = "0.1"
 async-buf-pool =  { git= "https://github.com:/logdna/async-buf-pool-rs.git", branch="0.3.x", version = "0.3"}
 pin-project = "1"
 
-#http
+#http/net
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "tcp", "http2"] }
+trust-dns-resolver = "0.22"
 
 #tls
 rustls = "0.20"
 hyper-rustls = { version = "0.23", features = ["http2", "logging"] }
 
 #utils
+backoff = "0.4"
 log = "0.4"
 time = "0.3"
 derivative = "2"
+once_cell = "1"
 smallvec = "1"
 countme = "2"
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -105,7 +105,7 @@ impl hyper::body::HttpBody for IngestBodyBuffer {
 }
 
 /// Type used to construct a body for an IngestRequest
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Eq)]
 pub struct IngestBody {
     lines: Vec<Line>,
 }
@@ -200,7 +200,7 @@ pub trait LineBufferMut: LineMetaMut {
 }
 
 /// Defines a log line, marking none required fields as Option
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Line {
     /// The annotations field, which is a key value map
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -389,7 +389,7 @@ impl Line {
 ///    .build()
 ///    .expect("Line::builder()");
 /// ```
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct LineBuilder {
     pub annotations: Option<KeyValueMap>,
     pub app: Option<String>,
@@ -778,7 +778,7 @@ impl AsRef<IngestBody> for IngestBody {
 }
 
 /// Json key value map (json object with a depth of 1)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyValueMap(HashMap<String, String>);
 
 impl Deref for KeyValueMap {

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,131 @@
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{self, Poll};
+
+use backoff::{backoff::Backoff, exponential::ExponentialBackoff, SystemClock};
+use hyper::client::connect::dns as hyper_dns;
+use hyper::service::Service;
+use once_cell::sync::Lazy;
+use tokio::sync::Mutex;
+use trust_dns_resolver::{
+    config::{ResolverConfig, ResolverOpts},
+    lookup_ip::LookupIpIntoIter,
+    system_conf, AsyncResolver, TokioConnection, TokioConnectionProvider, TokioHandle,
+};
+
+struct ResolverInner {
+    resolver: AsyncResolver<TokioConnection, TokioConnectionProvider>,
+    backoff: ExponentialBackoff<SystemClock>,
+}
+
+type SharedResolver = Arc<Mutex<ResolverInner>>;
+
+static SYSTEM_CONF: Lazy<io::Result<(ResolverConfig, ResolverOpts)>> =
+    Lazy::new(|| system_conf::read_system_conf().map_err(io::Error::from));
+
+#[derive(Clone)]
+pub(crate) struct TrustDnsResolver {
+    state: Arc<Mutex<State>>,
+}
+
+pub(crate) struct SocketAddrs {
+    iter: LookupIpIntoIter,
+}
+
+#[derive(Clone)]
+enum State {
+    Init(Option<ExponentialBackoff<SystemClock>>),
+    Ready(SharedResolver),
+}
+
+impl TrustDnsResolver {
+    pub(crate) fn new() -> io::Result<Self> {
+        SYSTEM_CONF.as_ref().map_err(|e| {
+            io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
+        })?;
+
+        // At this stage, we might not have been called in the context of a
+        // Tokio Runtime, so we must delay the actual construction of the
+        // resolver.
+        Ok(TrustDnsResolver {
+            state: Arc::new(Mutex::new(State::Init(Some(ExponentialBackoff::default())))),
+        })
+    }
+}
+
+impl Service<hyper_dns::Name> for TrustDnsResolver {
+    type Response = SocketAddrs;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, name: hyper_dns::Name) -> Self::Future {
+        let resolver = self.clone();
+        Box::pin(async move {
+            let mut lock = resolver.state.lock().await;
+
+            let resolver = match &mut *lock {
+                State::Init(backoff) => {
+                    let resolver = Arc::new(Mutex::new(ResolverInner {
+                        resolver: new_resolver().await?,
+                        backoff: backoff.take().expect("attempting to reinitialise resolver"),
+                    }));
+                    *lock = State::Ready(resolver.clone());
+                    resolver
+                }
+                State::Ready(resolver) => resolver.clone(),
+            };
+
+            // Don't keep lock once the resolver is constructed, otherwise
+            // only one lookup could be done at a time.
+            drop(lock);
+
+            let lookup = loop {
+                let mut resolver = resolver.lock().await;
+                match resolver.resolver.lookup_ip(name.as_str()).await {
+                    Ok(lookup) => {
+                        resolver.backoff.reset();
+                        break lookup;
+                    }
+                    Err(e) => {
+                        if let Some(delay) = resolver.backoff.next_backoff() {
+                            drop(resolver);
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        }
+                        return Err(e)?;
+                    }
+                }
+            };
+            Ok(SocketAddrs {
+                iter: lookup.into_iter(),
+            })
+        })
+    }
+}
+
+impl Iterator for SocketAddrs {
+    type Item = SocketAddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|ip_addr| SocketAddr::new(ip_addr, 0))
+    }
+}
+
+async fn new_resolver() -> Result<
+    AsyncResolver<TokioConnection, TokioConnectionProvider>,
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let (config, opts) = SYSTEM_CONF
+        .as_ref()
+        .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error")
+        .clone();
+    let resolver = AsyncResolver::new(config, opts, TokioHandle)?;
+    Ok(resolver)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod response;
 /// Log line and body serialization
 pub mod serialize;
 
+mod dns;
 mod segmented_buffer;
 
 #[cfg(test)]

--- a/src/segmented_buffer.rs
+++ b/src/segmented_buffer.rs
@@ -390,7 +390,7 @@ impl<F> SegmentedPoolBuf<F, Buffer, AllocBufferFn> {
 
 impl<F> Clone for SegmentedPoolBuf<F, Buffer, AllocBufferFn> {
     fn clone(&self) -> Self {
-        let mut reader = (&self.buf).bytes_reader();
+        let mut reader = self.buf.bytes_reader();
         let mut ret = self.duplicate();
         std::io::copy(&mut reader, &mut ret).unwrap();
         ret


### PR DESCRIPTION
This adds a new DNS provider that enforces a global backoff on dns requests. Hyper takes care of caching the dns result further up, so this should be hit very infrequently unless there is no dns server available