### PR TITLE
Refresh dns system config on error

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -355,17 +355,14 @@ impl<'a> IngestLineSerialize<String, bytes::Bytes, HashMap<String, String>> for 
         Ok(())
     }
     fn field_count(&self) -> usize {
-        2 + if Option::is_none(&self.annotations) {
-            0
-        } else {
-            1
-        } + if Option::is_none(&self.app) { 0 } else { 1 }
-            + if Option::is_none(&self.env) { 0 } else { 1 }
-            + if Option::is_none(&self.file) { 0 } else { 1 }
-            + if Option::is_none(&self.host) { 0 } else { 1 }
-            + if Option::is_none(&self.labels) { 0 } else { 1 }
-            + if Option::is_none(&self.level) { 0 } else { 1 }
-            + if Option::is_none(&self.meta) { 0 } else { 1 }
+        2 + usize::from(!Option::is_none(&self.annotations))
+            + usize::from(!Option::is_none(&self.app))
+            + usize::from(!Option::is_none(&self.env))
+            + usize::from(!Option::is_none(&self.file))
+            + usize::from(!Option::is_none(&self.host))
+            + usize::from(!Option::is_none(&self.labels))
+            + usize::from(!Option::is_none(&self.level))
+            + usize::from(!Option::is_none(&self.meta))
     }
 }
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -102,7 +102,10 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
                                 (Ok(ref mut new_system_config), Ok(system_config))
                                     if new_system_config != system_config =>
                                 {
-                                    std::mem::swap(system_config, new_system_config)
+                                    std::mem::swap(system_config, new_system_config);
+                                    let (config, opts) = system_config.clone();
+                                    resolver.resolver =
+                                        AsyncResolver::new(config, opts, TokioHandle)?;
                                 }
                                 _ => (),
                             }


### PR DESCRIPTION
This makes the dns resolver refresh itself from the system config if it encounters an error.